### PR TITLE
Fix partner features

### DIFF
--- a/app/mailers/cucumber_mailer.rb
+++ b/app/mailers/cucumber_mailer.rb
@@ -1,25 +1,29 @@
 class CucumberMailer < ApplicationMailer
   default to: 'tech@shopbeam.com'
 
-  def partners_completed(text, success)
+  def partners_completed(text, status_type)
     @text = text
 
-    mail subject: "[order-manager:partners] #{status(success)}" do |format|
+    mail subject: "[order-manager:partners] #{to_status(status_type)}" do |format|
       format.text { render 'completed' }
     end
   end
 
-  def widgets_completed(text, success)
+  def widgets_completed(text, status_type)
     @text = text
 
-    mail subject: "[order-manager:widgets] #{status(success)}" do |format|
+    mail subject: "[order-manager:widgets] #{to_status(status_type)}" do |format|
       format.text { render 'completed' }
     end
   end
 
   private
 
-  def status(success)
-    success ? 'OK' : 'ACTION REQUIRED: FAILED'
+  def to_status(status_type)
+    case status_type
+    when :ok      then 'OK'
+    when :warning then 'WARNING'
+    when :failed  then 'ACTION REQUIRED: FAILED'
+    end
   end
 end

--- a/features/partners/well_ca.feature
+++ b/features/partners/well_ca.feature
@@ -20,7 +20,7 @@ Feature: Purchase on well.ca
   Scenario: Purchase products
     Given the following products
       | quantity | sale_price_cents | source_url |
-      | 1        | 2499             | https://well.ca/products/skip-hop-zoo-packs-little-kid_89736.html |
+      | 1        | 1231             | https://well.ca/products/jamieson-vitamin-b12-fast-dissolving_20410.html |
     And  I am registered user
     When I go to landing page
     And  I close subscription popup
@@ -30,7 +30,7 @@ Feature: Purchase on well.ca
     And  I add products to cart
     And  I remove samples
     And  I go to checkout page
-    And  I skip recomendations
+    And  I skip recommendations
     And  I skip samples
     And  I fill shipping address
     And  I fill billing info

--- a/features/steps/base/base_purchase_steps.rb
+++ b/features/steps/base/base_purchase_steps.rb
@@ -1,0 +1,10 @@
+When(/^I add products to cart$/) do
+  begin
+    @products.each do |product|
+      @bot.send(:add_to_cart, product)
+    end
+  rescue Checkout::ItemOutOfStockError => exception
+    puts "[WARNING] #{exception.message}"
+    Cucumber.wants_to_quit = true
+  end
+end

--- a/features/steps/lacoste_com_us/lacoste_purchase_steps.rb
+++ b/features/steps/lacoste_com_us/lacoste_purchase_steps.rb
@@ -1,12 +1,12 @@
 Before('@lacoste', '@purchase') do
   address = {
-    state: 'CA',
     first_name: 'John',
     last_name: 'Smith',
     address1: '1 Infinite Loop',
     address2: 'Cupertino, CA 95014',
-    zip: 95014,
-    city: 'Cupertino'
+    city: 'Cupertino',
+    state: 'CA',
+    zip: 95014
   }
   @bot = Checkout::LacosteComUs::Bot.new(
     double(
@@ -35,12 +35,6 @@ Given(/^the following products$/) do |table|
       color: hash[:color],
       size: hash[:size]
     )
-  end
-end
-
-When(/^I add products to cart$/) do
-  @products.each do |product|
-    @bot.send(:add_to_cart, product)
   end
 end
 

--- a/features/steps/well_ca/well_ca_purchase_steps.rb
+++ b/features/steps/well_ca/well_ca_purchase_steps.rb
@@ -1,7 +1,12 @@
 Before('@well_ca', '@purchase') do
   address = {
-    state: 'AB',
-    gender: 'm'
+    gender: 'm',
+    first_name: 'John',
+    last_name: 'Smith',
+    address1: '123 test st.',
+    city: 'Toronto',
+    state: 'ON',
+    zip: 'A1A 1A1'
   }
   @bot = Checkout::WellCa::Bot.new(
     double(
@@ -25,7 +30,8 @@ Given(/^the following products$/) do |table|
     double(
       source_url: hash[:source_url],
       quantity: hash[:quantity].to_i,
-      sale_price_cents: hash[:sale_price_cents].to_i
+      sale_price_cents: hash[:sale_price_cents].to_i,
+      mark_as_out_of_stock!: true
     )
   end
 end
@@ -55,12 +61,6 @@ When(/^I remove alternate addresses$/) do
   @bot.send(:delete_alternate_addresses)
 end
 
-When(/^I add products to cart$/) do
-  @products.each do |product|
-    @bot.send(:add_to_cart, product)
-  end
-end
-
 When(/^I remove samples$/) do
   @bot.send(:remove_samples, @products)
 
@@ -72,7 +72,7 @@ When(/^I go to checkout page$/) do
   @browser.goto Checkout::WellCa::Bot::CHECKOUT_URL
 end
 
-When(/^I skip recomendations$/) do
+When(/^I skip recommendations$/) do
   @bot.send(:skip_recommendations)
 end
 

--- a/lib/tasks/partner_check.rake
+++ b/lib/tasks/partner_check.rake
@@ -5,18 +5,25 @@ namespace :cucumber do
     results = [:well_ca, :lacoste].map do |partner|
       `RAILS_ENV=test bundle exec rake cucumber:partners:#{partner}`
     end
+
     result = results.join("\n")
-    success = !result.match(/Failing Scenarios:/)
-    CucumberMailer.partners_completed(result, success).deliver_now
+    status_type =
+      case result
+      when /failing scenarios/i then :failed
+      when /warning/i           then :warning
+      else :ok
+      end
+
+    CucumberMailer.partners_completed(result, status_type).deliver_now
   end
 
   namespace :partners do
     Cucumber::Rake::Task.new(:well_ca) do |t|
-      t.cucumber_opts = "features/partners/well_ca.feature -r features/support -r features/steps/well_ca/"
+      t.cucumber_opts = "features/partners/well_ca.feature -r features/support -r features/steps/base -r features/steps/well_ca"
     end
 
     Cucumber::Rake::Task.new(:lacoste) do |t|
-      t.cucumber_opts = "features/partners/lacoste_com_us.feature -r features/support -r features/steps/lacoste_com_us/"
+      t.cucumber_opts = "features/partners/lacoste_com_us.feature -r features/support -r features/steps/base -r features/steps/lacoste_com_us"
     end
   end
 end

--- a/lib/tasks/widgets_check.rake
+++ b/lib/tasks/widgets_check.rake
@@ -6,8 +6,9 @@ namespace :cucumber do
       `RAILS_ENV=test bundle exec rake cucumber:widgets:#{widget}`
     end
     result = results.join("\n")
-    success = !result.match(/Failing Scenarios:/)
-    CucumberMailer.widgets_completed(result, success).deliver_now
+    status_type = result.match(/failing scenarios/i) ? :failed : :ok
+
+    CucumberMailer.widgets_completed(result, status_type).deliver_now
   end
 
   namespace :widgets do


### PR DESCRIPTION
Fixes the following issue:

```
   And I add products to cart       # features/steps/well_ca/well_ca_purchase_steps.rb:58
     #<Double (anonymous)> received unexpected message :mark_as_out_of_stock! with (no args) (RSpec::Mocks::MockExpectationError)
     ./lib/checkout/well_ca/bot.rb:141:in `rescue in add_to_cart'
     ./lib/checkout/well_ca/bot.rb:106:in `add_to_cart'
     ./features/steps/well_ca/well_ca_purchase_steps.rb:60:in `block (2 levels) in <top (required)>'
     ./features/steps/well_ca/well_ca_purchase_steps.rb:59:in `each'
     ./features/steps/well_ca/well_ca_purchase_steps.rb:59:in `/^I add products to cart$/'
     features/partners/well_ca.feature:30:in `And I add products to cart'
```

Also treats the cases when item is out of stock as a warning and aborts the suite.

cc: @necroua @bryanchriswhite 
