### PR TITLE
Fix Lacoste features

### DIFF
--- a/lib/checkout/lacoste_com_us/bot.rb
+++ b/lib/checkout/lacoste_com_us/bot.rb
@@ -24,6 +24,8 @@ module Checkout
       def add_to_cart(item)
         browser.goto item.source_url
 
+        close_monetize_popup
+
         variations = browser.element(class: 'product-variations')
 
         select_color(item, variations) if item.color.present?
@@ -115,6 +117,15 @@ module Checkout
 
         on_error do |message|
           raise ConfirmationError.new(browser.url, message)
+        end
+      end
+
+      def close_monetize_popup
+        popup = browser.element(id: 'monetate_lightbox')
+
+        if popup.present?
+          popup.click
+          popup.wait_while_present
         end
       end
 


### PR DESCRIPTION
We need to close a popup when navigate to some items.
This fixes the following issue:

```
   When I add products to cart  # features/steps/base/base_purchase_steps.rb:1
     unknown error: Element is not clickable at point (704, 396). Other element would receive the click: <img xmlns="http://www.w3.org/1999/xhtml" alt="" src="http://b.monetate.net/img/1/641/440991.jpg" />
       (Session info: chrome=44.0.2403.89)
       (Driver info: chromedriver=2.19.346067 (6abd8652f8bc7a1d825962003ac88ec6a37a82f1),platform=Linux 3.13.0-48-generic x86_64) (Selenium::WebDriver::Error::UnknownError)
     ./lib/checkout/lacoste_com_us/bot.rb:131:in `block in select_color'
     ./lib/checkout/browser.rb:29:in `wait_for_ajax'
     ./lib/checkout/lacoste_com_us/bot.rb:131:in `select_color'
     ./lib/checkout/lacoste_com_us/bot.rb:29:in `add_to_cart'
     ./features/steps/base/base_purchase_steps.rb:4:in `block (2 levels) in <top (required)>'
     ./features/steps/base/base_purchase_steps.rb:3:in `each'
     ./features/steps/base/base_purchase_steps.rb:3:in `/^I add products to cart$/'
     features/partners/lacoste_com_us.feature:15:in `When I add products to cart'
```

cc: @necroua @bryanchriswhite 
