### PR TITLE
Skip phone number during checkout

### DIFF
--- a/features/steps/lacoste_com_us/lacoste_purchase_steps.rb
+++ b/features/steps/lacoste_com_us/lacoste_purchase_steps.rb
@@ -6,7 +6,8 @@ Before('@lacoste', '@purchase') do
     address2: 'Cupertino, CA 95014',
     city: 'Cupertino',
     state: 'CA',
-    zip: 95014
+    zip: 95014,
+    phone: '123.456.7890'
   }
   @bot = Checkout::LacosteComUs::Bot.new(
     double(

--- a/lib/checkout/lacoste_com_us/bot.rb
+++ b/lib/checkout/lacoste_com_us/bot.rb
@@ -161,7 +161,6 @@ module Checkout
 
       def fill_shipping_address
         fill_address(shipping_address, 'sa')
-        browser.text_field(name: 'sa-phone').set shipping_address[:phone]
       end
 
       def fill_address(data, prefix)


### PR DESCRIPTION
It fixes the following issue:

```
Shopbeam order #420824 has been terminated due to the site failure:

invalid element state: Element is not currently interactable and may not be manipulated
 (Session info: chrome=44.0.2403.89)
 (Driver info: chromedriver=2.19.346067 (6abd8652f8bc7a1d825962003ac88ec6a37a82f1),platform=Linux 3.13.0-48-generic x86_64)
```

cc: @bryanchriswhite @necroua 
