### PR TITLE
Implement popup closer extension

### DIFF
--- a/features/partners/lacoste_com_us.feature
+++ b/features/partners/lacoste_com_us.feature
@@ -10,7 +10,7 @@ Feature: Purchase on lacoste.com/us
       | quantity | sale_price_cents | color                     | size | source_url |
       | 1        | 8950             | Chine                     | 2    | http://www.lacoste.com/us/lacoste/men/clothing/polos/short-sleeve-original-heathered-pique-polo/L1264-51.html |
       | 2        | 18500            | Navy Blue/cake Flour Whit | 3    | http://www.lacoste.com/us/lacoste/men/clothing/sweaters/honeycomb-stripe-sweatshirt-/AH1887-51.html |
-      | 1        | 12500            | Black                     |      | http://www.lacoste.com/us/lacoste/women/accessories/watches/lacoste.12.12-watch/2010766.html?dwvar_2010766_color=000 |
+      | 1        | 12500            | Grey                      |      | http://www.lacoste.com/us/lacoste/women/accessories/watches/lacoste.12.12-watch/2010767.html |
       | 2        | 5000             | Monaco Blue               |      | http://www.lacoste.com/us/lacoste-sport/men/tennis/lacoste-sport-cap-in-microfiber-with-oversized-crocodile/RK2464-51.html?dwvar_RK2464-51_color=001 |
     When I add products to cart
     And  I go to checkout page

--- a/features/partners/well_ca.feature
+++ b/features/partners/well_ca.feature
@@ -23,7 +23,6 @@ Feature: Purchase on well.ca
       | 1        | 2999             | https://well.ca/products/luna-caramel-nut-brownie-bars_12539.html |
     And  I am registered user
     When I go to landing page
-    And  I close subscription popup
     And  I sign in
     And  I empty cart
     And  I remove alternate addresses

--- a/features/steps/lacoste_com_us/lacoste_purchase_steps.rb
+++ b/features/steps/lacoste_com_us/lacoste_purchase_steps.rb
@@ -20,7 +20,7 @@ Before('@lacoste', '@purchase') do
         cvv: '000',
         brand: :visa,
         expiration_month: '1',
-        expiration_year: 2020
+        expiration_year: Time.now.year + 5
       }
     )
   )

--- a/features/steps/well_ca/well_ca_purchase_steps.rb
+++ b/features/steps/well_ca/well_ca_purchase_steps.rb
@@ -18,7 +18,7 @@ Before('@well_ca', '@purchase') do
         number: '4444333322221111',
         cvv: '000',
         expiration_month: '01',
-        expiration_year: 2020
+        expiration_year: Time.now.year + 5
       }
     )
   )
@@ -43,10 +43,6 @@ end
 
 When(/^I go to landing page$/) do
   @browser.goto Checkout::WellCa::Bot::BASE_URL
-end
-
-When(/^I close subscription popup$/) do
-  @bot.send(:close_subscription_popup)
 end
 
 When(/^I sign in$/) do

--- a/lib/checkout/browser.rb
+++ b/lib/checkout/browser.rb
@@ -1,5 +1,9 @@
 module Checkout
   class Browser < DelegateClass(Watir::Browser)
+    include ::Checkout::BrowserExtensions
+
+    TIMEOUT = 60 # seconds
+
     def initialize(driver: :chrome, headless: { display: Headless::DEFAULT_DISPLAY_NUMBER })
       if headless
         display = headless[:display] % Headless::MAX_DISPLAY_NUMBER
@@ -8,6 +12,8 @@ module Checkout
       end
 
       super Watir::Browser.new(driver)
+
+      Watir.default_timeout = TIMEOUT
     end
 
     def open
@@ -19,6 +25,17 @@ module Checkout
     def close
       super
       @headless.destroy if @headless
+    end
+
+    def goto(*)
+      super
+      close_popup
+    end
+
+    def click_on(el)
+      close_popup
+      wait_for_ajax { el.click }
+      close_popup
     end
 
     def on_page?(page_url)

--- a/lib/checkout/browser_extensions.rb
+++ b/lib/checkout/browser_extensions.rb
@@ -1,0 +1,9 @@
+module Checkout
+  module BrowserExtensions
+    extend ActiveSupport::Concern
+
+    included do
+      include PopupCloser
+    end
+  end
+end

--- a/lib/checkout/browser_extensions/popup_closer.rb
+++ b/lib/checkout/browser_extensions/popup_closer.rb
@@ -1,0 +1,30 @@
+module Checkout
+  module BrowserExtensions
+    module PopupCloser
+      def close_popup
+        elements(xpath: PopupFinder.xpath).each do |popup|
+          if popup.present?
+            popup.click
+            popup.wait_while_present
+          end
+        end
+      end
+    end
+
+    module PopupFinder
+      class << self
+        SELECTORS = [
+          ['id', 'monetate_lightbox'],
+          ['class', 'ui-dialog-titlebar-close']
+        ]
+
+        def xpath
+          @xpath ||= begin
+            nodes = SELECTORS.map { |attribute, value| "contains(@#{attribute}, '#{value}')" }
+            "//*[#{nodes.join(' or ')}]"
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/checkout/lacoste_com_us/bot.rb
+++ b/lib/checkout/lacoste_com_us/bot.rb
@@ -24,7 +24,11 @@ module Checkout
       def add_to_cart(item)
         browser.goto item.source_url
 
-        close_monetize_popup
+        add_to_cart_btn = browser.element(id: 'add-to-cart')
+
+        unless add_to_cart_btn.present?
+          raise VariantNotAvailableError.new(browser.url, item)
+        end
 
         variations = browser.element(class: 'product-variations')
 
@@ -42,7 +46,7 @@ module Checkout
         end
 
         item.quantity.times do
-          browser.element(id: 'add-to-cart').click
+          browser.click_on browser.element(id: 'add-to-cart')
           browser.element(class: 'mini-cart')
             .tap(&:wait_until_present)
             .tap(&:wait_while_present)
@@ -62,7 +66,7 @@ module Checkout
         browser.text_field(name: 'lastname').set proxy_user.last_name
         browser.text_field(name: 'email2').set browser.text_field(name: 'email1').value
         browser.checkbox(name: 'receivenews').clear
-        browser.wait_for_ajax { browser.button(id: 'js-checkout-register-guest').click }
+        browser.click_on browser.button(id: 'js-checkout-register-guest')
 
         on_error do |message|
           raise InvalidAccountError.new(browser.url, message)
@@ -80,9 +84,7 @@ module Checkout
       end
 
       def validate_order
-        browser.wait_for_ajax do
-          browser.button(text: /\Avalidate and review my order\z/i).click
-        end
+        browser.click_on browser.button(text: /\Avalidate and review my order\z/i)
 
         on_error do |message|
           raise InvalidAddressError.new(browser.url, message)
@@ -90,7 +92,7 @@ module Checkout
 
         browser.element(css: '.dialog.active').when_present do |dialog|
           if dialog.radio(name: 'address', value: 'found').present?
-            browser.wait_for_ajax { browser.button(id: 'acceptDavCheck').click }
+            browser.click_on browser.button(id: 'acceptDavCheck')
           else
             raise InvalidAddressError.new(browser.url, dialog.ps.last.text)
           end
@@ -110,22 +112,10 @@ module Checkout
         browser.text_field(id: 'npm-card-number').set session.cc[:number]
         browser.text_field(id: 'npm-cryptogramme').set session.cc[:cvv]
         browser.checkbox(name: 'check-condition').set
-
-        browser.wait_for_ajax do
-          browser.button(text: /\Aconfirm my order\z/i).click
-        end
+        browser.click_on browser.button(text: /\Aconfirm my order\z/i)
 
         on_error do |message|
           raise ConfirmationError.new(browser.url, message)
-        end
-      end
-
-      def close_monetize_popup
-        popup = browser.element(id: 'monetate_lightbox')
-
-        if popup.present?
-          popup.click
-          popup.wait_while_present
         end
       end
 
@@ -139,7 +129,7 @@ module Checkout
             raise VariantNotAvailableError.new(browser.url, item)
           end
 
-          browser.wait_for_ajax { color.click }
+          browser.click_on color
         end
       end
 
@@ -156,7 +146,7 @@ module Checkout
 
       def sign_in(email)
         browser.text_field(name: 'email').set email
-        browser.wait_for_ajax { browser.button(id: 'js-validate-email').click }
+        browser.click_on browser.button(id: 'js-validate-email')
       end
 
       def fill_shipping_address

--- a/lib/checkout/shopper.rb
+++ b/lib/checkout/shopper.rb
@@ -4,7 +4,6 @@ module Checkout
 
     def call(order_id)
       order = Order.uncompleted.find(order_id)
-
       session = Session.new(order)
 
       order.process!

--- a/lib/checkout/well_ca/bot.rb
+++ b/lib/checkout/well_ca/bot.rb
@@ -22,7 +22,6 @@ module Checkout
       def purchase!(items)
         browser.open do
           browser.goto BASE_URL
-          close_subscription_popup
 
           if new_user?
             sign_up
@@ -48,16 +47,6 @@ module Checkout
 
       private
 
-      def close_subscription_popup
-        begin
-          browser
-            .element(css: "[aria-labelledby='ui-dialog-title-newsletter_subscribe_auto']")
-            .tap(&:wait_until_present)
-            .element(class: 'ui-dialog-titlebar-close')
-            .click
-        rescue Watir::Wait::TimeoutError; end
-      end
-
       def sign_up
         browser.goto REGISTRATION_URL
         browser.radio(name: 'gender', value: 'o').set
@@ -67,7 +56,7 @@ module Checkout
         browser.text_field(name: 'email_address').set proxy_user.email
         browser.text_field(name: 'password').set proxy_user.password
         browser.text_field(name: 'confirmation').set proxy_user.password
-        browser.input(type: 'submit', value: /join/i).click
+        browser.click_on browser.input(type: 'submit', value: /join/i)
 
         on_error do |message|
           raise InvalidAccountError.new(browser.url, message)
@@ -80,7 +69,7 @@ module Checkout
         browser.goto LOGIN_URL
         browser.text_field(name: 'email_address').set proxy_user.email
         browser.text_field(name: 'password').set proxy_user.password
-        browser.input(type: 'submit', value: /sign in/i).click
+        browser.click_on browser.input(type: 'submit', value: /sign in/i)
 
         on_error(LOGIN_URL) do |message|
           raise InvalidAccountError.new(browser.url, message)
@@ -135,7 +124,7 @@ module Checkout
         end
 
         browser.text_field(id: 'cart_quantity').set item.quantity
-        browser.element(id: 'add_to_cart_button').click
+        browser.click_on browser.element(id: 'add_to_cart_button')
         browser.element(id: 'shopping-cart-dropdown').wait_until_present
       rescue ItemOutOfStockError
         item.mark_as_out_of_stock!
@@ -177,7 +166,7 @@ module Checkout
         end
 
         fill_address(shipping_address)
-        browser.input(type: 'submit', value: /submit|update/i).click
+        browser.click_on browser.input(type: 'submit', value: /submit|update/i)
 
         on_error do |message|
           raise InvalidAddressError.new(browser.url, message)
@@ -186,7 +175,7 @@ module Checkout
         continue_btn = browser.input(type: 'submit', value: /\Acontinue\z/i)
 
         if continue_btn.present?
-          continue_btn.click
+          browser.click_on continue_btn
         else
           raise InvalidShippingInfoError.new(browser.url, 'Invalid shipping info.')
         end
@@ -197,7 +186,7 @@ module Checkout
         fill_payment_info
 
         continue_btn = browser.buttons(value: /\Acontinue\z/i).last
-        continue_btn.click
+        browser.click_on continue_btn
 
         # Wait for page with 3rd party iframe to reload
         continue_btn.wait_while_present
@@ -209,7 +198,7 @@ module Checkout
       end
 
       def confirm_order
-        browser.input(type: 'submit', value: /confirm/i).click
+        browser.click_on browser.input(type: 'submit', value: /confirm/i)
 
         on_error do |message|
           raise ConfirmationError.new(browser.url, message)
@@ -223,7 +212,7 @@ module Checkout
       def fill_billing_address
         browser.goto EDIT_BILLING_ADDRESS_URL
         fill_address(billing_address)
-        browser.input(type: 'submit', value: /submit|update/i).click
+        browser.click_on browser.input(type: 'submit', value: /submit|update/i)
 
         on_error do |message|
           raise InvalidAddressError.new(browser.url, message)


### PR DESCRIPTION
It also fixes the following failure:

```
  When I add products to cart  # features/steps/base/base_purchase_steps.rb:1
      unable to locate element, using {:id=>"add-to-cart"} (Watir::Exception::UnknownObjectException)
      ./lib/checkout/lacoste_com_us/bot.rb:45:in `block in add_to_cart'
      ./lib/checkout/lacoste_com_us/bot.rb:44:in `times'
      ./lib/checkout/lacoste_com_us/bot.rb:44:in `add_to_cart'
      ./features/steps/base/base_purchase_steps.rb:4:in `block (2 levels) in <top (required)>'
      ./features/steps/base/base_purchase_steps.rb:3:in `each'
      ./features/steps/base/base_purchase_steps.rb:3:in `/^I add products to cart$/'
      features/partners/lacoste_com_us.feature:15:in `When I add products to cart'
```

@necroua @bryanchriswhite 
