### PR TITLE
Fix Lacoste features

### DIFF
--- a/features/partners/lacoste_com_us.feature
+++ b/features/partners/lacoste_com_us.feature
@@ -9,7 +9,7 @@ Feature: Purchase on lacoste.com/us
     Given the following products
       | quantity | sale_price_cents | color                     | size | source_url |
       | 1        | 8950             | Chine                     | 2    | http://www.lacoste.com/us/lacoste/men/clothing/polos/short-sleeve-original-heathered-pique-polo/L1264-51.html |
-      | 2        | 18500            | Navy Blue/cake Flour Whit | 5    | http://www.lacoste.com/us/lacoste/men/clothing/sweaters/honeycomb-stripe-sweatshirt-/AH1887-51.html |
+      | 2        | 20500            | Navy Blue/Officer Blue    | 5    | http://www.lacoste.com/us/lacoste/men/clothing/sweaters/double-face-crewneck-sweatshirt-/AH1885-51.html |
       | 1        | 12500            | Black                     |      | http://www.lacoste.com/us/lacoste/women/accessories/watches/lacoste.12.12-watch/2010766.html |
       | 2        | 5000             | Monaco Blue               |      | http://www.lacoste.com/us/lacoste-sport/men/tennis/lacoste-sport-cap-in-microfiber-with-oversized-crocodile/RK2464-51.html?dwvar_RK2464-51_color=001 |
     When I add products to cart

--- a/features/support/hooks.rb
+++ b/features/support/hooks.rb
@@ -1,3 +1,7 @@
+Before('@partners, @widgets') do
+  WebMock.allow_net_connect!
+end
+
 After('@partners, @widgets') do
   @browser.close if @browser
 end

--- a/features/support/webmock.rb
+++ b/features/support/webmock.rb
@@ -1,0 +1,1 @@
+require 'webmock/cucumber'

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -5,6 +5,7 @@ require File.expand_path('../../config/environment', __FILE__)
 abort("The Rails environment is running in production mode!") if Rails.env.production?
 require 'spec_helper'
 require 'rspec/rails'
+require 'webmock/rspec'
 # Add additional requires below this line. Rails is not loaded until this point!
 
 # Requires supporting ruby files with custom matchers and macros, etc, in

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -16,8 +16,6 @@
 # users commonly want.
 #
 # See http://rubydoc.info/gems/rspec-core/RSpec/Core/Configuration
-require 'webmock/rspec'
-
 RSpec.configure do |config|
   # rspec-expectations config goes here. You can use an alternate
   # assertion/expectation library such as wrong or the stdlib/minitest


### PR DESCRIPTION
Ensure item availability on AJAX requests on product detail page.
This fixes the following issue:

```
 When I add products to cart
     unable to locate element, using {:css=>"[itemprop=\"price\"]"} (Watir::Exception::UnknownObjectException)
     ./lib/checkout/lacoste_com_us/bot.rb:38:in `add_to_cart'
     ./features/steps/base/base_purchase_steps.rb:4:in `block (2 levels) in <top (required)>'
     ./features/steps/base/base_purchase_steps.rb:3:in `each'
     ./features/steps/base/base_purchase_steps.rb:3:in `/^I add products to cart$/'
     features/partners/lacoste_com_us.feature:15:in `When I add products to cart'
```
